### PR TITLE
Get internal function to eliminate check note

### DIFF
--- a/R/rtf.R
+++ b/R/rtf.R
@@ -29,9 +29,10 @@ rtf_assemble <- function(path) {
   end <- vapply(rtf, length, numeric(1))
   end[-n] <- end[-n] - 1
 
+  as_rtf_new_page <- get("as_rtf_new_page", asNamespace("r2rtf"))
   for (i in 1:n) {
     rtf[[i]] <- rtf[[i]][start[i]:end[i]]
-    if (i < n) rtf[[i]] <- c(rtf[[i]], r2rtf:::as_rtf_new_page())
+    if (i < n) rtf[[i]] <- c(rtf[[i]], as_rtf_new_page())
   }
   rtf <- do.call(c, rtf)
 


### PR DESCRIPTION
This PR uses ✨  magic ✨  to eliminate the `R CMD check` note:

```
* checking dependencies in R code ... NOTE
Unexported object imported by a ':::' call: 'r2rtf:::as_rtf_new_page'
  See the note in ?`:::` about the use of this operator.
```

Here are the implications:

- This can eliminate the check note immediately.
- This will continue to work even if that function is exported in r2rtf in the future.
- This will break if that function is removed or renamed in r2rtf in the future.