### PR TITLE
Check oldrel as now it is 4.1 thus supports `|>`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,7 +22,7 @@ jobs:
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
-        # - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR reverts https://github.com/Merck/metalite/commit/4306e4595e6a0ef124d649fa846138280c72306d to check on oldrel.

As R oldrel becomes 4.1, now all essential versions (devel, release, oldrel) support the native pipe operator `|>` and should be checked.

This also means you can submit to CRAN once other aspects are ready - there is no technical limit on using `|>` anymore.