### PR TITLE
Allow additional variables in the listing

### DIFF
--- a/R/collect_n_subject.R
+++ b/R/collect_n_subject.R
@@ -93,6 +93,7 @@ meta_remove_blank_group <- function(meta,
 #' @inheritParams define_population
 #' @param listing a logical value to display drill down listing per row.
 #' @param histogram a logical value to display histogram by group. 
+#' @param var_listing a character vector of additional variables included in the listing.  
 #' @param remove_blank_group a logical value to remove a group with all missing value of a parameter. 
 #' @param use_na a character value for whether to include NA values in the table. Refer `useNA` argument in `table` function for more details.
 #' @param display_total a logical value to display total column. 
@@ -110,6 +111,7 @@ collect_n_subject <- function(meta,
                               parameter, 
                               listing = FALSE, 
                               histogram = FALSE,
+                              var_listing = NULL,
                               remove_blank_group = FALSE,
                               use_na = c("ifany", "no", "always"), 
                               display_total = TRUE){
@@ -127,7 +129,7 @@ collect_n_subject <- function(meta,
   }
   
   # Obtain variables
-  par_var <- collect_adam_mapping(meta, parameter)$var
+  par_var <- unique(c(collect_adam_mapping(meta, parameter)$var, var_listing))
   
   # Obtain Data
   pop <- collect_population_record(meta, population, var = par_var)

--- a/R/collect_n_subject.R
+++ b/R/collect_n_subject.R
@@ -129,10 +129,10 @@ collect_n_subject <- function(meta,
   }
   
   # Obtain variables
-  par_var <- unique(c(collect_adam_mapping(meta, parameter)$var, var_listing))
+  par_var <- collect_adam_mapping(meta, parameter)$var
   
   # Obtain Data
-  pop <- collect_population_record(meta, population, var = par_var)
+  pop <- collect_population_record(meta, population, var = c(var_listing, par_var) )
   
   # Obtain ID
   pop_id <- collect_adam_mapping(meta, population)$id

--- a/man/collect_n_subject.Rd
+++ b/man/collect_n_subject.Rd
@@ -10,6 +10,7 @@ collect_n_subject(
   parameter,
   listing = FALSE,
   histogram = FALSE,
+  var_listing = NULL,
   remove_blank_group = FALSE,
   use_na = c("ifany", "no", "always"),
   display_total = TRUE
@@ -27,6 +28,8 @@ The term name is used as key to link information.}
 \item{listing}{a logical value to display drill down listing per row.}
 
 \item{histogram}{a logical value to display histogram by group.}
+
+\item{var_listing}{a character vector of additional variables included in the listing.}
 
 \item{remove_blank_group}{a logical value to remove a group with all missing value of a parameter.}
 


### PR DESCRIPTION
add `var_listing` argument to allow additional variables in the listing. 