### PR TITLE
Remove stringr from `Suggests` as it's not being used

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Suggests:
     knitr,
     r2rtf,
     rmarkdown,
-    stringr,
     testthat (>= 3.0.0),
     tibble
 Config/testthat/edition: 3


### PR DESCRIPTION
This PR removes stringr from `Suggests` as it's not being used in the package.