### PR TITLE
Add `url` to `_pkgdown.yml`

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,7 @@
 destination: docs
 
+url: https://merck.github.io/metalite/
+
 template:
   bootstrap: 5
   bslib:


### PR DESCRIPTION
This PR fixes https://github.com/Merck/metalite/issues/118 by adding the essential `url` field to `_pkgdown.yml`.