### PR TITLE
Add CRAN badges back

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 <!-- badges: start -->
 
-[![R-CMD-check](https://github.com/Merck/metalite/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Merck/metalite/actions/workflows/R-CMD-check.yaml)
+[![CRAN status](https://www.r-pkg.org/badges/version/metalite)](https://CRAN.R-project.org/package=metalite)
 [![Codecov test coverage](https://codecov.io/gh/Merck/metalite/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Merck/metalite?branch=main)
+[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/metalite)](https://CRAN.R-project.org/package=metalite)
+[![R-CMD-check](https://github.com/Merck/metalite/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Merck/metalite/actions/workflows/R-CMD-check.yaml)
 [![status](https://tinyverse.netlify.com/badge/metalite)](https://tinyverse.netlify.app/)
 
 <!-- badges: end -->


### PR DESCRIPTION
This PR adds the two CRAN-related badges to the readme... as it's now on CRAN so the URL check can pass! 🥳 