### PR TITLE
Fix argument name and style in news

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # metalite 0.1.3
 
-- Add argument `na_name` for `n_subject()`
-- Update GitHub Actions workflows
+- `n_subject()` now has a new argument `na` for labeling missing values.
+- Update GitHub Actions workflows.
 
 # metalite 0.1.2
 


### PR DESCRIPTION
This PR fixes the argument name and style in the news items added by https://github.com/Merck/metalite/pull/147.