### PR TITLE
bug fix: keep factor rows with completely missing values

### DIFF
--- a/R/collect_n_subject.R
+++ b/R/collect_n_subject.R
@@ -272,7 +272,6 @@ collect_n_subject <- function(meta,
 
   # standardize categorical variables
   if (any(c("factor", "character") %in% class_var)) {
-
     if (any(c("character") %in% class_var)) {
       var <- factor(var, exclude = NULL)
     }

--- a/R/collect_n_subject.R
+++ b/R/collect_n_subject.R
@@ -272,7 +272,10 @@ collect_n_subject <- function(meta,
 
   # standardize categorical variables
   if (any(c("factor", "character") %in% class_var)) {
-    var <- factor(var, exclude = NULL)
+
+    if (any(c("character") %in% class_var)) {
+      var <- factor(var, exclude = NULL)
+    }
 
     if (all(is.na(var))) {
       levels(var) <- c(levels(var), title["missing"])


### PR DESCRIPTION
The factor with empty factor should have a row as output 

```
meta <- meta_example() |>
  define_parameter(name = "sex", var = "SEX1", label = "Sex")
meta$data_population$SEX1 <- factor(meta$data_population$SEX, c("M", "F", "Other"))
collect_n_subject(meta, "apat", "sex")
```

```
                name     Placebo Xanomeline Low Dose Xanomeline High Dose        Total
1 Number of Subjects          86                  84                   84          254
2                Sex        <NA>                <NA>                 <NA>         <NA>
3 Subjects with Data          86                  84                   84          254
4                  M 33 ( 38.4%)         34 ( 40.5%)          44 ( 52.4%) 111 ( 43.7%)
5                  F 53 ( 61.6%)         50 ( 59.5%)          40 ( 47.6%) 143 ( 56.3%)
6              Other  0 (  0.0%)          0 (  0.0%)           0 (  0.0%)   0 (  0.0%)
```

Also tested in `metalite.table1` that works as expected after the code change. 

```
metalite.table1::metalite_table1(~ SEX1 | TRTA, data = meta$data_population)
``` 

![image](https://github.com/user-attachments/assets/ccac00b2-2085-4e33-b2a8-efe5e6db9129)
