### PR TITLE
Update tinyverse badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Codecov test coverage](https://codecov.io/gh/Merck/metalite/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Merck/metalite?branch=main)
 [![CRAN Downloads](https://cranlogs.r-pkg.org/badges/metalite)](https://CRAN.R-project.org/package=metalite)
 [![R-CMD-check](https://github.com/Merck/metalite/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Merck/metalite/actions/workflows/R-CMD-check.yaml)
-[![status](https://tinyverse.netlify.com/badge/metalite)](https://tinyverse.netlify.app/)
+[![status](https://tinyverse.netlify.app/badge/metalite)](https://cran.r-project.org/package=metalite)
 
 <!-- badges: end -->
 


### PR DESCRIPTION
This PR updates the tinyverse badge link as the previous tinyverse.netlify.com link is now changed to tinyverse.netlify.app.