### PR TITLE
Allow flexible format control for collect_n_subject

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,4 +44,4 @@ Suggests:
     tibble
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/collect_n_subject.R
+++ b/R/collect_n_subject.R
@@ -242,11 +242,11 @@ collect_n_subject <- function(meta,
         median = stats::median(x, na.rm = TRUE),
         min = min(x, na.rm = TRUE),
         max = max(x, na.rm = TRUE),
-        q1 = stats::quantile(x, probs=0.25, na.rm = TRUE, type = quantile_method, names = FALSE),
-        q3 = stats::quantile(x, probs=0.75, na.rm = TRUE, type = quantile_method, names = FALSE)
+        q1 = stats::quantile(x, probs = 0.25, na.rm = TRUE, type = quantile_method, names = FALSE),
+        q3 = stats::quantile(x, probs = 0.75, na.rm = TRUE, type = quantile_method, names = FALSE)
       )
       value <- formatC(value, format = "f", digits = decimal_places_summary)
-      c(gluestick("{value[['mean']]} ({value[['sd']]})"), gluestick("{value[['median']]} [{value[['min']]}, {value[['max']]}]"),gluestick("{value[['q1']]} to {value[['q3']]}"))
+      c(gluestick("{value[['mean']]} ({value[['sd']]})"), gluestick("{value[['median']]} [{value[['min']]}, {value[['max']]}]"), gluestick("{value[['q1']]} to {value[['q3']]}"))
     })
     pop_num <- data.frame(
       name = c("Mean (SD)", "Median [Min, Max]", "Q1 to Q3"),

--- a/man/collect_n_subject.Rd
+++ b/man/collect_n_subject.Rd
@@ -14,7 +14,10 @@ collect_n_subject(
   remove_blank_group = FALSE,
   type = "Subjects",
   use_na = c("ifany", "no", "always"),
-  display_total = TRUE
+  display_total = TRUE,
+  quantile_method = 2,
+  decimal_places_summary = 1,
+  decimal_places_percent = 1
 )
 }
 \arguments{
@@ -43,6 +46,12 @@ e.g., Subjects or Records.}
 in the table. See the \code{useNA} argument in \code{\link[base:table]{base::table()}} for more details.}
 
 \item{display_total}{A logical value to display total column.}
+
+\item{quantile_method}{An integer between 1 and 9 selecting one of the nine quantile algorithms to be used for \code{type} argument in \code{\link[stats:quantile]{stats::quantile()}}. Default is 2 as the same percentile definition used by the UNIVARIATE procedure in SAS.}
+
+\item{decimal_places_summary}{Number of decimal places to be displayed in statistical summary values (Mean, SD, Median, Min, Max, Q1 and Q3). Default is 1.}
+
+\item{decimal_places_percent}{Number of decimal places to be displayed in percentage values. Default is 1.}
 }
 \value{
 A list containing number of subjects and its subset condition.

--- a/tests/testthat/test-independent-testing-collect_n_subject.R
+++ b/tests/testthat/test-independent-testing-collect_n_subject.R
@@ -178,11 +178,11 @@ test_that("test collect_n_subject with continous parameter", {
       median = stats::median(x, na.rm = TRUE),
       min = min(x, na.rm = TRUE),
       max = max(x, na.rm = TRUE),
-      q1 = stats::quantile(x, probs=0.25, na.rm = TRUE, type = 2, names = FALSE),
-      q3 = stats::quantile(x, probs=0.75, na.rm = TRUE, type = 2, names = FALSE)
+      q1 = stats::quantile(x, probs = 0.25, na.rm = TRUE, type = 2, names = FALSE),
+      q3 = stats::quantile(x, probs = 0.75, na.rm = TRUE, type = 2, names = FALSE)
     )
     value <- formatC(value, format = "f", digits = 1)
-    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"),glue::glue("{value[['q1']]} to {value[['q3']]}"))
+    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"), glue::glue("{value[['q1']]} to {value[['q3']]}"))
   })
   pop_age <- data.frame(
     name = c("Mean (SD)", "Median [Min, Max]", "Q1 to Q3"),
@@ -269,11 +269,11 @@ test_that("test collect_n_subject with continous parameter", {
       median = stats::median(x, na.rm = TRUE),
       min = min(x, na.rm = TRUE),
       max = max(x, na.rm = TRUE),
-      q1 = stats::quantile(x, probs=0.25, na.rm = TRUE, type = 2, names = FALSE),
-      q3 = stats::quantile(x, probs=0.75, na.rm = TRUE, type = 2, names = FALSE)
+      q1 = stats::quantile(x, probs = 0.25, na.rm = TRUE, type = 2, names = FALSE),
+      q3 = stats::quantile(x, probs = 0.75, na.rm = TRUE, type = 2, names = FALSE)
     )
     value <- formatC(value, format = "f", digits = 1)
-    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"),glue::glue("{value[['q1']]} to {value[['q3']]}"))
+    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"), glue::glue("{value[['q1']]} to {value[['q3']]}"))
   })
   pop_age <- data.frame(
     name = c("Mean (SD)", "Median [Min, Max]", "Q1 to Q3"),
@@ -558,7 +558,7 @@ test_that("test collect_n_subject with decimal places formatting", {
   )
   ## test test1$n
   meta$data_population$AGE[2:5] <- NA
-  test1 <- collect_n_subject(meta, "apat", "age",decimal_places_summary = 2,decimal_places_percent = 3)
+  test1 <- collect_n_subject(meta, "apat", "age", decimal_places_summary = 2, decimal_places_percent = 3)
 
   meta_add <- meta_add_total(meta)
   pop <- collect_population_record(meta_add, "apat", "AGE")
@@ -586,11 +586,11 @@ test_that("test collect_n_subject with decimal places formatting", {
       median = stats::median(x, na.rm = TRUE),
       min = min(x, na.rm = TRUE),
       max = max(x, na.rm = TRUE),
-      q1 = stats::quantile(x, probs=0.25, na.rm = TRUE, type = 2, names = FALSE),
-      q3 = stats::quantile(x, probs=0.75, na.rm = TRUE, type = 2, names = FALSE)
+      q1 = stats::quantile(x, probs = 0.25, na.rm = TRUE, type = 2, names = FALSE),
+      q3 = stats::quantile(x, probs = 0.75, na.rm = TRUE, type = 2, names = FALSE)
     )
     value <- formatC(value, format = "f", digits = 2)
-    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"),glue::glue("{value[['q1']]} to {value[['q3']]}"))
+    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"), glue::glue("{value[['q1']]} to {value[['q3']]}"))
   })
   pop_age <- data.frame(
     name = c("Mean (SD)", "Median [Min, Max]", "Q1 to Q3"),

--- a/tests/testthat/test-independent-testing-collect_n_subject.R
+++ b/tests/testthat/test-independent-testing-collect_n_subject.R
@@ -177,13 +177,15 @@ test_that("test collect_n_subject with continous parameter", {
       sd = stats::sd(x, na.rm = TRUE),
       median = stats::median(x, na.rm = TRUE),
       min = min(x, na.rm = TRUE),
-      max = max(x, na.rm = TRUE)
+      max = max(x, na.rm = TRUE),
+      q1 = stats::quantile(x, probs=0.25, na.rm = TRUE, type = 2, names = FALSE),
+      q3 = stats::quantile(x, probs=0.75, na.rm = TRUE, type = 2, names = FALSE)
     )
     value <- formatC(value, format = "f", digits = 1)
-    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"))
+    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"),glue::glue("{value[['q1']]} to {value[['q3']]}"))
   })
   pop_age <- data.frame(
-    name = c("Mean (SD)", "Median [Min, Max]"),
+    name = c("Mean (SD)", "Median [Min, Max]", "Q1 to Q3"),
     do.call(cbind, pop_age)
   )
 
@@ -266,13 +268,15 @@ test_that("test collect_n_subject with continous parameter", {
       sd = stats::sd(x, na.rm = TRUE),
       median = stats::median(x, na.rm = TRUE),
       min = min(x, na.rm = TRUE),
-      max = max(x, na.rm = TRUE)
+      max = max(x, na.rm = TRUE),
+      q1 = stats::quantile(x, probs=0.25, na.rm = TRUE, type = 2, names = FALSE),
+      q3 = stats::quantile(x, probs=0.75, na.rm = TRUE, type = 2, names = FALSE)
     )
     value <- formatC(value, format = "f", digits = 1)
-    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"))
+    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"),glue::glue("{value[['q1']]} to {value[['q3']]}"))
   })
   pop_age <- data.frame(
-    name = c("Mean (SD)", "Median [Min, Max]"),
+    name = c("Mean (SD)", "Median [Min, Max]", "Q1 to Q3"),
     do.call(cbind, pop_age)
   )
 
@@ -544,4 +548,63 @@ test_that("test collect_n_subject with character parameter", {
 
   meta$data_population$USUBJID[1] <- meta$data_population$USUBJID[2]
   expect_warning(collect_n_subject(meta, "apat", "sex"))
+})
+
+
+test_that("test collect_n_subject with decimal places formatting", {
+  suppressWarnings(
+    meta <- meta_example() |>
+      define_parameter(name = "age", var = "AGE", label = "Age")
+  )
+  ## test test1$n
+  meta$data_population$AGE[2:5] <- NA
+  test1 <- collect_n_subject(meta, "apat", "age",decimal_places_summary = 2,decimal_places_percent = 3)
+
+  meta_add <- meta_add_total(meta)
+  pop <- collect_population_record(meta_add, "apat", "AGE")
+  Total <- length(unique(pop$USUBJID))
+  pop_all <- n_subject(pop$USUBJID, pop$TRTA)
+  pop_all <- data.frame(
+    name = "Number of Subjects",
+    pop_all
+  )
+  names(pop_all) <- c("name", "Placebo", "Xanomeline Low Dose", "Xanomeline High Dose", "Total")
+  expect_equal(test1$n, pop_all, ignore_attr = TRUE)
+  ## test test1$table
+  pop_all[2, ] <- c("Age", NA, NA, NA, NA)
+
+  pop_all_with_data <- n_subject(pop$USUBJID, pop$TRTA, par = factor(
+    is.na(pop[["AGE"]]),
+    c(FALSE, TRUE), c("Subjects with Data", "Missing")
+  ))
+  names(pop_all_with_data) <- c("name", "Placebo", "Xanomeline Low Dose", "Xanomeline High Dose", "Total")
+
+  pop_age <- tapply(pop$AGE, pop$TRTA, function(x) {
+    value <- c(
+      mean = mean(x, na.rm = TRUE),
+      sd = stats::sd(x, na.rm = TRUE),
+      median = stats::median(x, na.rm = TRUE),
+      min = min(x, na.rm = TRUE),
+      max = max(x, na.rm = TRUE),
+      q1 = stats::quantile(x, probs=0.25, na.rm = TRUE, type = 2, names = FALSE),
+      q3 = stats::quantile(x, probs=0.75, na.rm = TRUE, type = 2, names = FALSE)
+    )
+    value <- formatC(value, format = "f", digits = 2)
+    c(glue::glue("{value[['mean']]} ({value[['sd']]})"), glue::glue("{value[['median']]} [{value[['min']]}, {value[['max']]}]"),glue::glue("{value[['q1']]} to {value[['q3']]}"))
+  })
+  pop_age <- data.frame(
+    name = c("Mean (SD)", "Median [Min, Max]", "Q1 to Q3"),
+    do.call(cbind, pop_age)
+  )
+
+  names(pop_age) <- c("name", "Placebo", "Xanomeline Low Dose", "Xanomeline High Dose", "Total")
+
+  pop_pct <- pop_all_with_data
+  for (i in 2:ncol(pop_all_with_data)) {
+    pct <- formatC(pop_all_with_data[, i] / as.numeric(pop_all[1, i]) * 100, format = "f", digits = 3, width = 5)
+    pop_pct[, i] <- glue::glue("{pop_all_with_data[,i]} ({pct}%)")
+  }
+
+  pop_n <- rbind(pop_all, pop_all_with_data[1, ], pop_age, pop_pct[2, ])
+  expect_equal(test1$table, pop_n, ignore_attr = TRUE)
 })


### PR DESCRIPTION
1. Add argument `decimal_places_summary` to control decimal places for statistical summary
2. Add argument `decimal_places_percent` to control decimal places for percentage
3. Add argument `quantile_method` to control quantile algorithms to be used for `type` argument in [stats::quantile()]
4. Add row 'Q1 to Q3' in statistical summary section